### PR TITLE
add `pip wheel`/PEP517 build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 GitHub Action: PyPI Deployment
 ==============================
 
+[![Test](https://github.com/casperdcl/deploy-pypi/actions/workflows/test.yml/badge.svg)](https://github.com/casperdcl/deploy-pypi/actions/workflows/test.yml)
+
 Securely build and upload Python distributions to PyPI.
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Securely build and upload Python distributions to PyPI.
       - uses: actions/setup-python@v2
       - uses: casperdcl/deploy-pypi@v2
         with:
-          password: ${{ secrets.pypi_token }}
-          build: true
+          password: ${{ secrets.PYPI_TOKEN }}
+          pip: wheel -w dist/ --no-deps .
           # only upload if a tag is pushed (otherwise just build & check)
           upload: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags') }}
 ```
@@ -24,6 +24,7 @@ PyPI Deployment:
 - Supports `build`ing
   + supports customisable build requirements
   + supports customisable build command
+  + supports [PEP517](https://www.python.org/dev/peps/pep-0517) projects lacking a `setup.py` file
 - Supports GPG signing
 - Each stage is optional (`build`, `check`, `sign` and `upload`)
 - Uses a blazing fast native GitHub composite action
@@ -55,6 +56,9 @@ inputs:
     default: twine wheel
   build:
     description: '`setup.py` command to run ("true" is a shortcut for "clean sdist -d <dist_dir> bdist_wheel -d <dist_dir>")'
+    default: false
+  pip:
+    description: '`pip` command to run ("true" is a shortcut for "wheel -w <dist_dir> --no-deps .")'
     default: false
   check:
     description: Whether to run basic checks on the built files

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: '`setup.py` command to run ("true" is a shortcut for "clean sdist -d <dist_dir> bdist_wheel -d <dist_dir>")'
     required: false
     default: false
+  pip:
+    description: '`pip` command to run ("true" is a shortcut for "wheel -w <dist_dir> --no-deps .")'
+    required: false
+    default: false
   check:
     description: Whether to run basic checks on the built files
     required: false
@@ -62,6 +66,11 @@ runs:
         if [[ -n "$INPUT_REQUIREMENTS" && "$INPUT_BUILD" != false ]]; then
           python -m pip install $INPUT_REQUIREMENTS
         fi
+        if [[ "$INPUT_PIP" == wheel* ]]; then
+          python -m pip $INPUT_PIP
+        elif [[ "$INPUT_PIP" == true ]]; then
+          python -m pip wheel -w "$INPUT_DIST_DIR" --no-deps .
+        fi
         if [[ "$INPUT_BUILD" == *build* || "$INPUT_BUILD" == *dist* || "$INPUT_BUILD" == *clean* ]]; then
           python setup.py $INPUT_BUILD
         elif [[ "$INPUT_BUILD" == true ]]; then
@@ -71,6 +80,7 @@ runs:
       env:
         INPUT_REQUIREMENTS: ${{ inputs.requirements }}
         INPUT_BUILD: ${{ inputs.build }}
+        INPUT_PIP: ${{ inputs.pip }}
         INPUT_DIST_DIR: ${{ inputs.dist_dir }}
     - name: check
       run: |


### PR DESCRIPTION
- allows building projects without `setup.py` (https://www.python.org/dev/peps/pep-0517)
  + allows auto-determining requirements
- update docs
- fixes #9